### PR TITLE
Enhance audio parsing

### DIFF
--- a/PTT/handlers.py
+++ b/PTT/handlers.py
@@ -240,14 +240,15 @@ def add_defaults(parser: Parser):
     parser.add_handler("codec", handle_space_in_codec)
 
     # Channels
-    parser.add_handler("channels", regex.compile(r"\bDDP?5[ \.\_]1\b", regex.IGNORECASE), uniq_concat(value("5.1")), {"remove": False})
-    parser.add_handler("channels", regex.compile(r"\b5\.1(ch)?\b", regex.IGNORECASE), uniq_concat(value("5.1")), {"remove": False})
-    parser.add_handler("channels", regex.compile(r"\b7[\.\- ]1(.?ch(annel)?)?\b", regex.IGNORECASE), uniq_concat(value("7.1")), {"remove": False})
-    parser.add_handler("channels", regex.compile(r"\b2\.0\b", regex.IGNORECASE), uniq_concat(value("2.0")), {"remove": False})
-    parser.add_handler("channels", regex.compile(r"\bstereo\b", regex.IGNORECASE), uniq_concat(value("stereo")), {"remove": False})
+    parser.add_handler("channels", regex.compile(r"\bD(olby)?D([+P]|PA)?.?5[._ ]1\b", regex.IGNORECASE), uniq_concat(value("5.1")), {"remove": False})
+    parser.add_handler("channels", regex.compile(r"\b5[._ ]1(ch(annel)?)?(?:x[2-4])?\b", regex.IGNORECASE), uniq_concat(value("5.1")), {"remove": True})
+    parser.add_handler("channels", regex.compile(r"\b6(ch(annel)?s?|[._ ]0)\b", regex.IGNORECASE), uniq_concat(value("5.1")), {"remove": False})
+    parser.add_handler("channels", regex.compile(r"\bD(olby)?D[+P]?.?2[._ ]0\b", regex.IGNORECASE), uniq_concat(value("2.0")), {"remove": False, "skipIfAlreadyFound": False})
+    parser.add_handler("channels", regex.compile(r"\b7[._ ]1(ch(annel)?)?\b", regex.IGNORECASE), uniq_concat(value("7.1")), {"remove": False, "skipIfAlreadyFound": False})
+    parser.add_handler("channels", regex.compile(r"\b(AAC)?2(ch(annel)?|[._ ]0)(?:x[2-4])?\b", regex.IGNORECASE), uniq_concat(value("2.0")), {"remove": False, "skipIfAlreadyFound": False})
+    parser.add_handler("channels", regex.compile(r"\bstereo\b", regex.IGNORECASE), uniq_concat(value("2.0")), {"remove": False})
     parser.add_handler("channels", regex.compile(r"\bmono\b", regex.IGNORECASE), uniq_concat(value("mono")), {"remove": False})
-    parser.add_handler("channels", regex.compile(r"\b(?:x[2-4]|5[\W]1(?:x[2-4])?)\b", regex.IGNORECASE), uniq_concat(value("5.1")), {"remove": True})
-    parser.add_handler("channels", regex.compile(r"\b2\.0(?:x[2-4])\b", regex.IGNORECASE), uniq_concat(value("2.0")), {"remove": True})
+    parser.add_handler("channels", regex.compile(r"\b2[._ ]0(?:x[2-4])\b", regex.IGNORECASE), uniq_concat(value("2.0")), {"remove": True, "skipIfAlreadyFound": False})
 
     # Audio
     parser.add_handler("audio", regex.compile(r"\bDTS.?X\b", regex.IGNORECASE), uniq_concat(value("DTS:X")), {"remove": True, "skipIfAlreadyFound": False})

--- a/PTT/handlers.py
+++ b/PTT/handlers.py
@@ -195,9 +195,9 @@ def add_defaults(parser: Parser):
     parser.add_handler("quality", regex.compile(r"\bTVRips?\b", regex.IGNORECASE), value("TVRip"), {"remove": True})
     parser.add_handler("quality", regex.compile(r"\bR5\b", regex.IGNORECASE), value("R5"), {"remove": True})
     parser.add_handler("quality", regex.compile(r"\b(?:DL|WEB|BD|BR)MUX\b", regex.IGNORECASE), value("WEBMux"), {"remove": True})
-    parser.add_handler("quality", regex.compile(r"\bWEB[ .-]*Rip\b", regex.IGNORECASE), value("WEBRip"), {"remove": True})
-    parser.add_handler("quality", regex.compile(r"\bWEB[ .-]?DL[ .-]?Rip\b", regex.IGNORECASE), value("WEB-DLRip"), {"remove": True})
-    parser.add_handler("quality", regex.compile(r"\bWEB[ .-]*(DL|.BDrip|.DLRIP)\b", regex.IGNORECASE), value("WEB-DL"), {"remove": True})
+    parser.add_handler("quality", regex.compile(r"\b(TRUE\.)?WEB[ .-]*Rip\b", regex.IGNORECASE), value("WEBRip"), {"remove": True})
+    parser.add_handler("quality", regex.compile(r"\b(TRUE\.)?WEB[ .-]?DL[ .-]?Rip\b", regex.IGNORECASE), value("WEB-DLRip"), {"remove": True})
+    parser.add_handler("quality", regex.compile(r"\b(TRUE\.)?WEB[ .-]*(DL|.BDrip|.DLRIP)\b", regex.IGNORECASE), value("WEB-DL"), {"remove": True})
     parser.add_handler("quality", regex.compile(r"\b(?<!\w.)WEB\b|\bWEB(?!([ \.\-\(\],]+\d))\b", regex.IGNORECASE), value("WEB"), {"remove": True, "skipFromTitle": True})  #
     parser.add_handler("quality", regex.compile(r"\b(?:H[DQ][ .-]*)?CAM(?!.?(S|E|\()\d+)(?:H[DQ])?(?:[ .-]*Rip|Rp)?\b", regex.IGNORECASE), value("CAM"), {"remove": True, "skipFromTitle": True})  # can appear in a title as well, check it last
     parser.add_handler("quality", regex.compile(r"\b(?:H[DQ][ .-]*)?S[ \.\-]print", regex.IGNORECASE), value("CAM"), {"remove": True, "skipFromTitle": True})  # can appear in a title as well, check it last
@@ -250,22 +250,21 @@ def add_defaults(parser: Parser):
     parser.add_handler("channels", regex.compile(r"\b2\.0(?:x[2-4])\b", regex.IGNORECASE), uniq_concat(value("2.0")), {"remove": True})
 
     # Audio
-    parser.add_handler("audio", regex.compile(r"\bDDP5[ \.\_]1\b", regex.IGNORECASE), uniq_concat(value("Dolby Digital Plus")), {"remove": True, "skipIfFirst": True})
     parser.add_handler("audio", regex.compile(r"\bDTS.?X\b", regex.IGNORECASE), uniq_concat(value("DTS:X")), {"remove": True, "skipIfAlreadyFound": False})
     parser.add_handler("audio", regex.compile(r"\b(?!.+HR)(DTS.?HD.?Ma(ster)?)\b", regex.IGNORECASE), uniq_concat(value("DTS-HD MA")), {"remove": True, "skipIfAlreadyFound": False})
     parser.add_handler("audio", regex.compile(r"\bDTS(?!(.?HD.?Ma(ster)?|.?X)).?(HD.?HR|HD)\b", regex.IGNORECASE), uniq_concat(value("DTS-HD")), {"remove": True, "skipIfAlreadyFound": False})
     parser.add_handler("audio", regex.compile(r"\bDTS\b", regex.IGNORECASE), uniq_concat(value("DTS")), {"remove": True, "skipFromTitle": True, "skipIfFirst": True})
+    parser.add_handler("audio", regex.compile(r"\b(TrueHD|\.True\.)\b", regex.IGNORECASE), uniq_concat(value("Dolby TrueHD")), {"remove": True, "skipIfAlreadyFound": False, "skipFromTitle": True})
+    parser.add_handler("audio", regex.compile(r"\b(DD[+P].?[257]?[._ ]?[01]?|DD Plus|Dolby Digital Plus)\b", regex.IGNORECASE), uniq_concat(value("Dolby Digital Plus")), {"remove": True, "skipIfAlreadyFound": False})
+    parser.add_handler("audio", regex.compile(r"\bDDPA.?[57][._ ]1\b", regex.IGNORECASE), uniq_concat(value("Dolby Digital Plus")), {"remove": False, "skipIfAlreadyFound": False})
     parser.add_handler("audio", regex.compile(r"\b(Dolby.?)?Atmos\b", regex.IGNORECASE), uniq_concat(value("Atmos")), {"remove": True, "skipIfAlreadyFound": False})
-    parser.add_handler("audio", regex.compile(r"\b(TrueHD|\.True\.)\b", regex.IGNORECASE), uniq_concat(value("TrueHD")), {"remove": True, "skipIfAlreadyFound": False, "skipFromTitle": True})
-    parser.add_handler("audio", regex.compile(r"\bTRUE\b"), uniq_concat(value("TrueHD")), {"remove": True, "skipIfAlreadyFound": False, "skipFromTitle": True})
+    parser.add_handler("audio", regex.compile(r"\bDDPA.?[57][._ ]1\b", regex.IGNORECASE), uniq_concat(value("Atmos")), {"remove": True, "skipIfAlreadyFound": False})
+    parser.add_handler("audio", regex.compile(r"\b(D(olby)?D|Dolby.?Digital.?)[25._ ]?[25]?[._ ]?[01]?(?!.?(Plus|P|PA|\+))\b", regex.IGNORECASE), uniq_concat(value("Dolby Digital")), {"remove": True, "skipIfAlreadyFound": False})
     parser.add_handler("audio", regex.compile(r"\bFLAC(?:\+?2\.0)?(x[2-4])?\b", regex.IGNORECASE), uniq_concat(value("FLAC")), {"remove": True, "skipIfAlreadyFound": False})
     parser.add_handler("audio", regex.compile(r"\bEAC-?3(?:[. -]?[256]\.[01])?\b", regex.IGNORECASE), uniq_concat(value("EAC3")), {"remove": True, "skipIfAlreadyFound": False})
     parser.add_handler("audio", regex.compile(r"\bAC-?3(x2)?(?:[ .-](5\.1)?[x+]2\.?0?x?3?)?\b", regex.IGNORECASE), uniq_concat(value("AC3")), {"remove": True, "skipIfAlreadyFound": False})
-    parser.add_handler("audio", regex.compile(r"\b5\.1(ch)?\b", regex.IGNORECASE), uniq_concat(value("AC3")), {"remove": True, "skipIfAlreadyFound": True})
-    parser.add_handler("audio", regex.compile(r"\b(DD2?[\+p]2?(.?5.1)?|DD Plus|Dolby Digital Plus)\b", regex.IGNORECASE), uniq_concat(value("Dolby Digital Plus")), {"remove": True, "skipIfAlreadyFound": False})
-    parser.add_handler("audio", regex.compile(r"\b(DD|Dolby.?Digital.?)2?(5.?1)?(?!.?(Plus|P|\+))\b", regex.IGNORECASE), uniq_concat(value("Dolby Digital")), {"remove": True, "skipIfAlreadyFound": False})
-    parser.add_handler("audio", regex.compile(r"\bDolbyD\b", regex.IGNORECASE), uniq_concat(value("Dolby Digital")), {"remove": True, "skipIfFirst": True})
     parser.add_handler("audio", regex.compile(r"\bQ?Q?AAC(x?2)?\b", regex.IGNORECASE), uniq_concat(value("AAC")), {"remove": True, "skipIfAlreadyFound": False})
+    parser.add_handler("audio", regex.compile(r"\b5\.1(ch)?\b", regex.IGNORECASE), uniq_concat(value("AC3")), {"remove": True, "skipIfAlreadyFound": True})
     parser.add_handler("audio", regex.compile(r"\b(H[DQ])?.?(Clean.?Aud(io)?)\b", regex.IGNORECASE), uniq_concat(value("HQ Clean Audio")), {"remove": True, "skipIfAlreadyFound": False})
 
     # Group

--- a/PTT/handlers.py
+++ b/PTT/handlers.py
@@ -251,8 +251,10 @@ def add_defaults(parser: Parser):
 
     # Audio
     parser.add_handler("audio", regex.compile(r"\bDDP5[ \.\_]1\b", regex.IGNORECASE), uniq_concat(value("Dolby Digital Plus")), {"remove": True, "skipIfFirst": True})
-    parser.add_handler("audio", regex.compile(r"\b(?!.+HR)(DTS.?HD.?Ma(ster)?|DTS.?X)\b", regex.IGNORECASE), uniq_concat(value("DTS Lossless")), {"remove": True, "skipIfAlreadyFound": False})
-    parser.add_handler("audio", regex.compile(r"\bDTS(?!(.?HD.?Ma(ster)?|.X)).?(HD.?HR|HD)?\b", regex.IGNORECASE), uniq_concat(value("DTS Lossy")), {"remove": True, "skipIfAlreadyFound": False})
+    parser.add_handler("audio", regex.compile(r"\bDTS.?X\b", regex.IGNORECASE), uniq_concat(value("DTS:X")), {"remove": True, "skipIfAlreadyFound": False})
+    parser.add_handler("audio", regex.compile(r"\b(?!.+HR)(DTS.?HD.?Ma(ster)?)\b", regex.IGNORECASE), uniq_concat(value("DTS-HD MA")), {"remove": True, "skipIfAlreadyFound": False})
+    parser.add_handler("audio", regex.compile(r"\bDTS(?!(.?HD.?Ma(ster)?|.?X)).?(HD.?HR|HD)\b", regex.IGNORECASE), uniq_concat(value("DTS-HD")), {"remove": True, "skipIfAlreadyFound": False})
+    parser.add_handler("audio", regex.compile(r"\bDTS\b", regex.IGNORECASE), uniq_concat(value("DTS")), {"remove": True, "skipFromTitle": True, "skipIfFirst": True})
     parser.add_handler("audio", regex.compile(r"\b(Dolby.?)?Atmos\b", regex.IGNORECASE), uniq_concat(value("Atmos")), {"remove": True, "skipIfAlreadyFound": False})
     parser.add_handler("audio", regex.compile(r"\b(TrueHD|\.True\.)\b", regex.IGNORECASE), uniq_concat(value("TrueHD")), {"remove": True, "skipIfAlreadyFound": False, "skipFromTitle": True})
     parser.add_handler("audio", regex.compile(r"\bTRUE\b"), uniq_concat(value("TrueHD")), {"remove": True, "skipIfAlreadyFound": False, "skipFromTitle": True})

--- a/PTT/handlers.py
+++ b/PTT/handlers.py
@@ -28,12 +28,12 @@ def add_defaults(parser: Parser):
     """
     # Torrent extension
     parser.add_handler("torrent", regex.compile(r"\.torrent$"), boolean, {"remove": True})
- 
+
     # Adult
     parser.add_handler("adult", regex.compile(r"\b(?:xxx|xx)\b", regex.IGNORECASE), boolean, {"remove": True, "skipFromTitle": True})
     parser.add_handler("adult", create_adult_pattern(), boolean, {"remove": True, "skipFromTitle": True, "skipIfAlreadyFound": True})
 
-    # Anime  
+    # Anime
     # anime_handler(parser)  # adds too much time to overall parsing
 
     # Scene
@@ -332,6 +332,7 @@ def add_defaults(parser: Parser):
     parser.add_handler("seasons", regex.compile(r"(?<!\bEp?(?:isode)? ?\d+\b.*)\b(\d{2})[ ._]\d{2}(?:.F)?\.\w{2,4}$"), array(integer))
     parser.add_handler("seasons", regex.compile(r"\bEp(?:isode)?\W+(\d{1,2})\.\d{1,3}\b", regex.IGNORECASE), array(integer))
     parser.add_handler("seasons", regex.compile(r"\bSeasons?\b.*\b(\d{1,2}-\d{1,2})\b", regex.IGNORECASE), range_func)
+    parser.add_handler("seasons", regex.compile(r"(?:\W|^)(\d{1,2})(?:e|ep)\d{1,3}(?:\W|$)", regex.IGNORECASE), array(integer))
 
     # Episodes
     parser.add_handler("episodes", regex.compile(r"(?:[\W\d]|^)e[ .]?[([]?(\d{1,3}(?:[ .-]*(?:[&+]|e){1,2}[ .]?\d{1,3})+)(?:\W|$)", regex.IGNORECASE), range_func)
@@ -364,6 +365,7 @@ def add_defaults(parser: Parser):
     parser.add_handler("episodes", regex.compile(r"(\d+)(?=.?\[([A-Z0-9]{8})])", regex.IGNORECASE), array(integer))
     parser.add_handler("episodes", regex.compile(r"(?<![xh])\b264\b|\b265\b", regex.IGNORECASE), array(integer), {"remove": True})
     parser.add_handler("episodes", regex.compile(r"(?<!\bMovie\s-\s)(?<=\s-\s)\d+(?=\s[-(\s])"), array(integer), {"remove": True, "skipIfAlreadyFound": True})
+    parser.add_handler("episodes", regex.compile(r"(?:\W|^)(?:\d+)?(?:e|ep)(\d{1,3})(?:\W|$)", regex.IGNORECASE), array(integer))
 
     def handle_episodes(context):
         title = context["title"]
@@ -564,7 +566,7 @@ def add_defaults(parser: Parser):
 
     # Size
     parser.add_handler("size", regex.compile(r"\b(\d+(\.\d+)?\s?(MB|GB|TB))\b", regex.IGNORECASE), none, {"remove": True})
-    
+
     # Site
     parser.add_handler("site", regex.compile(r"\[([^\]]+\.[^\]]+)\](?=\.\w{2,4}$|\s)", regex.IGNORECASE), value("$1"), {"remove": True})
     parser.add_handler("site", regex.compile(r"\bwww\.\w*\.\w+\b", regex.IGNORECASE), value("$1"), {"remove": True})
@@ -594,7 +596,7 @@ def add_defaults(parser: Parser):
 
     # Group
     parser.add_handler("group", regex.compile(r"\(([\w-]+)\)(?:$|\.\w{2,4}$)"))
-    parser.add_handler("group", regex.compile(r"\b(INFLATE|DEFLATE)\b", ), value("$1"), {"remove": True})
+    parser.add_handler("group", regex.compile(r"\b(INFLATE|DEFLATE)\b"), value("$1"), {"remove": True})
     parser.add_handler("group", regex.compile(r"\b(?:Erai-raws|Erai-raws\.com)\b", regex.IGNORECASE), value("Erai-raws"), {"remove": True})
     parser.add_handler("group", regex.compile(r"^\[([^[\]]+)]"))
 
@@ -609,5 +611,5 @@ def add_defaults(parser: Parser):
     parser.add_handler("trash", regex.compile(r"acesse o original", regex.IGNORECASE), boolean, {"remove": True})
 
     # Title (hardcoded cleanup)
-    parser.add_handler("title", regex.compile(r"\b100[ .-]*years?[ .-]*quest\b", regex.IGNORECASE), none, {"remove": True}) # episode title
+    parser.add_handler("title", regex.compile(r"\b100[ .-]*years?[ .-]*quest\b", regex.IGNORECASE), none, {"remove": True})  # episode title
     parser.add_handler("title", regex.compile(r"\b(?:INTEGRALE?|INTÉGRALE?|INTERNAL|HFR)\b", regex.IGNORECASE), none, {"remove": True})

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -12,8 +12,8 @@ def parser():
 
 
 @pytest.mark.parametrize("release_name, expected_audio", [
-    ("Nocturnal Animals 2016 VFF 1080p BluRay DTS HEVC-HD2", ["DTS Lossy"]),
-    ("Gold 2016 1080p BluRay DTS-HD MA 5 1 x264-HDH", ["DTS Lossless"]),
+    ("Nocturnal Animals 2016 VFF 1080p BluRay DTS HEVC-HD2", ["DTS"]),
+    ("Gold 2016 1080p BluRay DTS-HD MA 5 1 x264-HDH", ["DTS-HD MA"]),
     ("Rain Man 1988 REMASTERED 1080p BRRip x264 AAC-m2g", ["AAC"]),
     ("The Vet Life S02E01 Dunk-A-Doctor 1080p ANPL WEB-DL AAC2 0 H 264-RTN", ["AAC"]),
     ("Jimmy Kimmel 2017 05 03 720p HDTV DD5 1 MPEG2-CTL", ["Dolby Digital"]),
@@ -28,7 +28,7 @@ def parser():
     ("Buttobi!! CPU - 02 (DVDRip 720x480p x265 HEVC AC3x2 2.0x2)(Dual Audio)[sxales].mkv", ["AC3"]),
     ("[naiyas] Fate Stay Night - Unlimited Blade Works Movie [BD 1080P HEVC10 QAACx2 Dual Audio]", ["AAC"]),
     ("Sakura Wars the Movie (2001) (BDRip 1920x1036p x265 HEVC FLACx2, AC3 2.0+5.1x2)(Dual Audio)[sxales].mkv", ["FLAC", "AC3"]),
-    ("Spider-Man.No.Way.Home.2021.2160p.BluRay.REMUX.HEVC.TrueHD.7.1.Atmos-FraMeSToR", ["Atmos", "TrueHD"]),
+    ("Spider-Man.No.Way.Home.2021.2160p.BluRay.REMUX.HEVC.TrueHD.7.1.Atmos-FraMeSToR", ["Dolby TrueHD", "Atmos"]),
     ("Monk.S01.1080p.AMZN.WEBRip.DDP2.0.x264-AJP69[rartv]", ["Dolby Digital Plus"]),
     ("Monk.S01E01E02.1080p.WEB-DL.DD2.0.x264-AJP69.mkv", ["Dolby Digital"]),
     ("Outlaw Star - 23 (BDRip 1440x1080p x265 HEVC AC3, FLACx2 2.0x3)(Dual Audio)[sxales].mkv", ["FLAC", "AC3"]),
@@ -42,8 +42,8 @@ def test_audio_detection(parser, release_name, expected_audio):
         assert "audio" not in result, f"Unexpected audio detection for {release_name}"
 
 @pytest.mark.parametrize("release_name, expected_audio", [
-    ("Macross ~ Do You Remember Love (1984) (BDRip 1920x1036p x265 HEVC DTS-HD MA, FLAC, AC3x2 5.1+2.0x3)(Dual Audio)[sxales].mkv", ["DTS Lossless", "FLAC", "AC3"]),
-    ("Escaflowne (2000) (BDRip 1896x1048p x265 HEVC TrueHD, FLACx3, AC3 5.1x2+2.0x3)(Triple Audio)[sxales].mkv", ["TrueHD", "FLAC", "AC3"]),
+    ("Macross ~ Do You Remember Love (1984) (BDRip 1920x1036p x265 HEVC DTS-HD MA, FLAC, AC3x2 5.1+2.0x3)(Dual Audio)[sxales].mkv", ["DTS-HD MA", "FLAC", "AC3"]),
+    ("Escaflowne (2000) (BDRip 1896x1048p x265 HEVC TrueHD, FLACx3, AC3 5.1x2+2.0x3)(Triple Audio)[sxales].mkv", ["Dolby TrueHD", "FLAC", "AC3"]),
     ("[SAD] Inuyasha - The Movie 4 - Fire on the Mystic Island [BD 1920x1036 HEVC10 FLAC2.0x2] [84E9A4A1].mkv", ["FLAC"]),
 ])
 def test_audio_detection_without_episode(parser, release_name, expected_audio):
@@ -69,28 +69,28 @@ def test_audio_detection_with_episode(parser, release_name, expected_audio, expe
         assert "audio" not in result, f"Unexpected audio detection for {release_name}"
 
 @pytest.mark.parametrize("release_name, expected_audio, expected_title", [
-    ("The Shawshank Redemption 1994.MULTi.1080p.Blu-ray.DTS-HDMA.5.1.HEVC-DDR[EtHD]", ["DTS Lossless"], "The Shawshank Redemption"),
-    ("Oppenheimer.2023.BluRay.1080p.DTS-HD.MA.5.1.AVC.REMUX-FraMeSToR.mkv", ["DTS Lossless"], "Oppenheimer"),
-    ("Guardians.of.the.Galaxy.Vol.3.2023.BluRay.1080p.DTS-HD.MA.7.1.x264-MTeam[TGx]", ["DTS Lossless"], "Guardians of the Galaxy Vol 3"),
-    ("Oppenheimer.2023.2160p.MA.WEB-DL.DUAL.DTS.HD.MA.5.1+DD+5.1.DV-HDR.H.265-TheBiscuitMan.mkv", ["DTS Lossless", "Dolby Digital Plus"], "Oppenheimer"),
-    ("The.Equalizer.3.2023.BluRay.1080p.DTS-HD.MA.5.1.x264-MTeam", ["DTS Lossless"], "The Equalizer 3"),
-    ("Point.Break.1991.2160p.Blu-ray.Remux.DV.HDR.HEVC.DTS-HD.MA.5.1-CiNEPHiLES.mkv", ["DTS Lossless"], "Point Break"),
-    ("The.Mechanic.2011.2160p.UHD.Blu-ray.Remux.DV.HDR.HEVC.DTS-HD.MA.5.1-CiNEPHiLES.mkv", ["DTS Lossless"], "The Mechanic"),
-    ("Face.Off.1997.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HEVC.REMUX-FraMeSToR.mkv", ["DTS Lossless"], "Face Off"),
-    ("Killers of the Flower Moon 2023 2160p UHD Blu-ray Remux HEVC DV DTS-HD MA 5.1-HDT.mkv", ["DTS Lossless"], "Killers of the Flower Moon"),
-    ("Ghostbusters.Frozen.Empire.2024.1080p.BluRay.ENG.LATINO.HINDI.ITA.DTS-HD.Master.5.1.H264-BEN.THE.MEN", ["DTS Lossless"], "Ghostbusters Frozen Empire"),
-    ("How.To.Train.Your.Dragon.2.2014.1080p.BluRay.ENG.LATINO.DTS-HD.Master.H264-BEN.THE.MEN", ["DTS Lossless"], "How To Train Your Dragon 2"),
-    ("【高清影视之家发布 www.HDBTHD.com】奥本海默[IMAX满屏版][简繁英字幕].Oppenheimer.2023.IMAX.2160p.BluRay.x265.10bit.DTS-HD.MA.5.1-CTRLHD", ["DTS Lossless"], "高清影视之家发布"),
-    ("Ocean's.Thirteen.2007.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HEVC.HYBRID.REMUX-FraMeSToR.mkv", ["DTS Lossless"], "Ocean's Thirteen"),
-    ("Sleepy.Hollow.1999.BluRay.1080p.2Audio.DTS-HD.HR.5.1.x265.10bit-ALT", ["DTS Lossy"], "Sleepy Hollow"),
-    ("The Flash 2023 WEBRip 1080p DTS DD+ 5.1 Atmos x264-MgB", ["DTS Lossy", "Atmos", "Dolby Digital Plus"], "The Flash"),
-    ("Indiana Jones and the Last Crusade 1989 BluRay 1080p DTS AC3 x264-MgB", ["DTS Lossy", "AC3"], "Indiana Jones and the Last Crusade"),
-    ("2012.London.Olympics.BBC.Bluray.Set.1080p.DTS-HD", ["DTS Lossy"], "London Olympics BBC"),
-    ("www.1TamilMV.phd - Oppenheimer (2023) English BluRay - 1080p - x264 - (DTS 5.1) - 7.3GB - ESub.mkv", ["DTS Lossy"], "Oppenheimer"),
-    ("【高清影视之家发布 www.HDBTHD.com】年会不能停！[60帧率版本][国语音轨+中文字幕].Johnny.Keep.Walking.2023.60FPS.2160p.WEB-DL.H265.10bit.DTS.5.1-GPTHD", ["DTS Lossy"], "高清影视之家发布"),
-    ("Big.Stan.2007.1080p.BluRay.Remux.DTS-HD.HR.5.1", ["DTS Lossy"], "Big Stan"),
-    ("Ditched.2022.1080p.Bluray.DTS-HD.HR.5.1.X264-EVO[TGx]", ["DTS Lossy"], "Ditched"),
-    ("Basic.Instinct.1992.Unrated.Directors.Cut.Bluray.1080p.DTS-HD-HR-6.1.x264-Grym@BTNET", ["DTS Lossy"], "Basic Instinct"),
+    ("The Shawshank Redemption 1994.MULTi.1080p.Blu-ray.DTS-HDMA.5.1.HEVC-DDR[EtHD]", ["DTS-HD MA"], "The Shawshank Redemption"),
+    ("Oppenheimer.2023.BluRay.1080p.DTS-HD.MA.5.1.AVC.REMUX-FraMeSToR.mkv", ["DTS-HD MA"], "Oppenheimer"),
+    ("Guardians.of.the.Galaxy.Vol.3.2023.BluRay.1080p.DTS-HD.MA.7.1.x264-MTeam[TGx]", ["DTS-HD MA"], "Guardians of the Galaxy Vol 3"),
+    ("Oppenheimer.2023.2160p.MA.WEB-DL.DUAL.DTS.HD.MA.5.1+DD+5.1.DV-HDR.H.265-TheBiscuitMan.mkv", ["DTS-HD MA", "Dolby Digital Plus"], "Oppenheimer"),
+    ("The.Equalizer.3.2023.BluRay.1080p.DTS-HD.MA.5.1.x264-MTeam", ["DTS-HD MA"], "The Equalizer 3"),
+    ("Point.Break.1991.2160p.Blu-ray.Remux.DV.HDR.HEVC.DTS-HD.MA.5.1-CiNEPHiLES.mkv", ["DTS-HD MA"], "Point Break"),
+    ("The.Mechanic.2011.2160p.UHD.Blu-ray.Remux.DV.HDR.HEVC.DTS-HD.MA.5.1-CiNEPHiLES.mkv", ["DTS-HD MA"], "The Mechanic"),
+    ("Face.Off.1997.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HEVC.REMUX-FraMeSToR.mkv", ["DTS-HD MA"], "Face Off"),
+    ("Killers of the Flower Moon 2023 2160p UHD Blu-ray Remux HEVC DV DTS-HD MA 5.1-HDT.mkv", ["DTS-HD MA"], "Killers of the Flower Moon"),
+    ("Ghostbusters.Frozen.Empire.2024.1080p.BluRay.ENG.LATINO.HINDI.ITA.DTS-HD.Master.5.1.H264-BEN.THE.MEN", ["DTS-HD MA"], "Ghostbusters Frozen Empire"),
+    ("How.To.Train.Your.Dragon.2.2014.1080p.BluRay.ENG.LATINO.DTS-HD.Master.H264-BEN.THE.MEN", ["DTS-HD MA"], "How To Train Your Dragon 2"),
+    ("【高清影视之家发布 www.HDBTHD.com】奥本海默[IMAX满屏版][简繁英字幕].Oppenheimer.2023.IMAX.2160p.BluRay.x265.10bit.DTS-HD.MA.5.1-CTRLHD", ["DTS-HD MA"], "高清影视之家发布"),
+    ("Ocean's.Thirteen.2007.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HEVC.HYBRID.REMUX-FraMeSToR.mkv", ["DTS-HD MA"], "Ocean's Thirteen"),
+    ("Sleepy.Hollow.1999.BluRay.1080p.2Audio.DTS-HD.HR.5.1.x265.10bit-ALT", ["DTS-HD"], "Sleepy Hollow"),
+    ("The Flash 2023 WEBRip 1080p DTS DD+ 5.1 Atmos x264-MgB", ["DTS", "Dolby Digital Plus", "Atmos"], "The Flash"),
+    ("Indiana Jones and the Last Crusade 1989 BluRay 1080p DTS AC3 x264-MgB", ["DTS", "AC3"], "Indiana Jones and the Last Crusade"),
+    ("2012.London.Olympics.BBC.Bluray.Set.1080p.DTS-HD", ["DTS-HD"], "London Olympics BBC"),
+    ("www.1TamilMV.phd - Oppenheimer (2023) English BluRay - 1080p - x264 - (DTS 5.1) - 7.3GB - ESub.mkv", ["DTS"], "Oppenheimer"),
+    ("【高清影视之家发布 www.HDBTHD.com】年会不能停！[60帧率版本][国语音轨+中文字幕].Johnny.Keep.Walking.2023.60FPS.2160p.WEB-DL.H265.10bit.DTS.5.1-GPTHD", ["DTS"], "高清影视之家发布"),
+    ("Big.Stan.2007.1080p.BluRay.Remux.DTS-HD.HR.5.1", ["DTS-HD"], "Big Stan"),
+    ("Ditched.2022.1080p.Bluray.DTS-HD.HR.5.1.X264-EVO[TGx]", ["DTS-HD"], "Ditched"),
+    ("Basic.Instinct.1992.Unrated.Directors.Cut.Bluray.1080p.DTS-HD-HR-6.1.x264-Grym@BTNET", ["DTS-HD"], "Basic Instinct"),
 ])
 def test_dts_separation(parser, release_name, expected_audio, expected_title):
     result = parser.parse(release_name)
@@ -106,7 +106,7 @@ def test_dts_separation(parser, release_name, expected_audio, expected_title):
 
 @pytest.mark.parametrize("release_name, expected_audio", [
     ("Madame Web (2024) 1080p HINDI ENGLISH 10bit AMZN WEBRip DDP5 1 x265 HEVC - PSA Shadow", ["Dolby Digital Plus"]),
-    ("[www.1TamilMV.pics]_The.Great.Indian.Suicide.2023.Tamil.TRUE.WEB-DL.4K.SDR.HEVC.(DD+5.1.384Kbps.&.AAC).3.2GB.ESub.mkv", ["TrueHD", "Dolby Digital Plus", "AAC"]),
+    ("[www.1TamilMV.pics]_The.Great.Indian.Suicide.2023.Tamil.TRUE.WEB-DL.4K.SDR.HEVC.(DD+5.1.384Kbps.&.AAC).3.2GB.ESub.mkv", ["Dolby Digital Plus", "AAC"]),
 ])
 def test_ddp_separation(parser, release_name, expected_audio):
     result = parser.parse(release_name)

--- a/tests/test_episodes.py
+++ b/tests/test_episodes.py
@@ -190,6 +190,7 @@ def parser():
     ("Anatomia De Grey - Temporada 19 [HDTV][Cap.1905][Castellano][www.AtomoHD.nu].avi", [1905]),
     ("[SubsPlease] Fairy Tail - 100 Years Quest - 05 (1080p) [1107F3A9].mkv", [5]),
     ("Mad.Max.Fury.Road.2015.1080p.BluRay.DDP5.1.x265.10bit-GalaxyRG265[TGx]", []),
+    ("Vikkatakavi 01E06.mkv", [6]),
 ])
 def test_episode_parser(release_name, expected_episode, parser):
     result = parser.parse(release_name)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -108,7 +108,7 @@ def parser():
         "title": "Maman, j'ai raté l'avion",
         "quality": "BluRay",
         "year": 1990,
-        "audio": ["DTS Lossy"],
+        "audio": ["DTS"],
         "resolution": "1080p",
         "languages": ["fr"],
         "codec": "hevc",
@@ -308,7 +308,7 @@ def parser():
         "quality": "BluRay REMUX",
         "resolution": "2160p",
         "channels": ["7.1"],
-        "audio": ["Atmos", "TrueHD"],
+        "audio": ["Dolby TrueHD", "Atmos"],
         "codec": "hevc",
         "languages": [],
         "seasons": [],
@@ -351,7 +351,7 @@ def parser():
         "quality": "BluRay",
         "codec": "hevc",
         "bit_depth": "10bit",
-        "audio": ["AC3", "AAC"],
+        "audio": ["AAC"],
         "channels": ["5.1"]
     }),
     ("[DB]_Bleach_264_[012073FE].avi", {
@@ -396,7 +396,7 @@ def parser():
         "edition": "Anniversary Edition",
         "quality": "BluRay REMUX",
         "resolution": "1080p",
-        "audio": ["DTS Lossless"],
+        "audio": ["DTS-HD MA"],
         "channels": ["5.1"],
         "codec": "avc",
         "group": "LEGi0N"
@@ -412,7 +412,7 @@ def parser():
         "quality": "BluRay",
         "codec": "hevc",
         "bit_depth": "10bit",
-        "audio": ["Atmos", "TrueHD"],
+        "audio": ["Dolby TrueHD", "Atmos"],
         "channels": ["7.1"],
         "hdr": ["HDR"],
         "group": "BOREDOR"
@@ -426,8 +426,8 @@ def parser():
         "quality": "BDRip",
         "codec": "hevc",
         "resolution": "1896x1048p",  # this needs to be 1080p instead probably
-        "audio": ["TrueHD", "FLAC", "AC3"],
-        "channels": ["5.1"],
+        "audio": ["Dolby TrueHD", "FLAC", "AC3"],
+        "channels": ["5.1", "2.0"],
         # "group": "sxales",
         "dubbed": True,
         "container": "mkv",
@@ -448,7 +448,7 @@ def parser():
         "container": "mkv",
         "extension": "mkv",
         "bitrate": "384kbps",
-        "audio": ["TrueHD", "Dolby Digital Plus", "AAC"],
+        "audio": ["Dolby Digital Plus", "AAC"],
         "channels": ["5.1"],
     }),
     ("www.5MovieRulz.show - Khel Khel Mein (2024) 1080p Hindi DVDScr - x264 - AAC - 2.3GB.mkv", {
@@ -503,7 +503,7 @@ def parser():
         "episodes": [],
         "quality": "BDRip",
         "codec": "hevc",
-        "audio": ["DTS Lossless"],
+        "audio": ["DTS-HD MA"],
         "channels": ["5.1"],
         "container": "mkv",
         "extension": "mkv",
@@ -712,7 +712,7 @@ def parser():
         "resolution": "1080p",
         "codec": "avc",
         "audio": ["Dolby Digital Plus"],
-        # "channels": ["2.0"],
+        "channels": ["2.0"],
         "group": "NTb",
         "extension": "mkv",
         "container": "mkv",
@@ -725,7 +725,7 @@ def parser():
         "languages": [],
         "resolution": "2160p",
         "codec": "hevc",
-        "audio": ["AC3", "Dolby Digital Plus"],
+        "audio": ["Dolby Digital Plus"],
         "channels": ["5.1"],
         "group": "DirtyHippie",
         "container": "mkv",
@@ -760,6 +760,7 @@ def parser():
         "quality": "PDTV",
         "codec": "avc",
         "audio": ["AAC"],
+        "channels": ["2.0"],
         "group": "BTN"
     }),
     ("www.1Tamilblasters.co - Guardians of the Galaxy Vol. 3 (2023) [4K IMAX UHD HEVC - BDRip - [Tam + Mal + Tel + Hin + Eng] - x264 - DDP5.1 (192Kbps) - 8.3GB - ESub].mkv", {
@@ -975,7 +976,7 @@ def parser():
         "resolution": "1080p",
         "quality": "HDTVRip",
         "codec": "avc",
-        "audio": ["AC3", "AAC"],
+        "audio": ["AAC"],
         "channels": ["5.1"],
         "group": "QRips",
         "size": "2.2GB"
@@ -1075,8 +1076,8 @@ def parser():
         "codec": "hevc",
         "container": "mkv",
         "audio": [
+            "Dolby Digital Plus",
             "Atmos",
-            "Dolby Digital Plus"
         ],
         "channels": [
             "5.1"

--- a/tests/test_season.py
+++ b/tests/test_season.py
@@ -111,6 +111,7 @@ def parser():
     ("Проклятие острова ОУК_ 5-й сезон 09-я серия_ Прорыв Дэна.avi", [5]),
     ("Разрушители легенд. MythBusters. Сезон 15. Эпизод 09. Скрытая угроза (2015).avi", [15]),
     ("Сезон 5/Серия 11.mkv", [5]),
+    ("Vikkatakavi 01E06.mkv", [1]),
 ])
 def test_season_detection(parser, release_name, expected_seasons):
     result = parser.parse(release_name)


### PR DESCRIPTION
- Create new handler for `Atmos`
  - Map `DDPA5.1` and `DDPA7.1` to `Atmos`
- Create separate handlers for `DTS-X` and `DTS`
- Update handlers for `Dolby Digital Plus`
- Rename `TrueHD` to `Dolby TrueHD`
- Rename`DTS Lossless` to `DTS-HD MA`
- Rename`DTS Lossy` to `DTS-HD`
- Fix wrong matching of `TRUE.WEB-DL` to `Dolby TrueHD`
- Fix wrong matching of AAC 5.1 to AAC and AC3
- Rearrange handlers for proper matching

Notes:
- Tests needs to be updated after initial review